### PR TITLE
Updated bash.sh to replace the isort version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,4 @@ dev = [
 addopts = "--cov=tpc_plugin_validator --cov-report term-missing --cov-report xml:coverage.xml"
 
 [tool.isort]
-py_version=310
+py_version={ PYTHON VERSION NO DOT }

--- a/setup.sh
+++ b/setup.sh
@@ -72,10 +72,13 @@ function setup_issue_templates {
 function set_python_version {
     header 'Python Version'
     read -rp 'What is the minimum targetted python version? ' python_min
+    python_version_no_dot="${python_min//.}"
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" '.github/workflows/uv.yml'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" '.python-version'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" 'pyproject.toml'
+    sed -i '' -e "s/{ PYTHON VERSION NO DOT }/$python_version_no_dot/g" 'pyproject.toml'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" 'sonar-project.properties'
+
     printf 'Updating the Python version across the project.'
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Update setup script and configuration to dynamically set isort's py_version based on the specified Python version

Enhancements:
- Introduce python_version_no_dot variable in setup.sh to strip dots from the Python version
- Replace hard-coded isort py_version in pyproject.toml with a placeholder that uses the no-dot Python version