### PR TITLE
Resolved issue with blame and stopped codeqwl scanning on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -15,7 +15,10 @@ jobs:
         python-version:
           - "{ PYTHON_VERSION }"
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
         with:


### PR DESCRIPTION
## Summary by Sourcery

Adjust GitHub Actions workflows to fetch full git history for accurate blame and disable CodeQL scanning on push events

Bug Fixes:
- Resolve issue with inaccurate git blame by ensuring full repository checkout

CI:
- Set fetch-depth: 0 in the UV workflow checkout step to retrieve full git history
- Remove push trigger from the CodeQL workflow so it runs only on pull requests and scheduled events