### PR TITLE
UV and workflow updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "{ PYTHON_VERSION }"
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: UV Build
+        run: uv build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -28,12 +28,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up Python
         run: uv python install
-      - name: Run pyTest
+      - name: pyTest
         run: uv run pytest tests
-      - name: Run Ruff
+      - name: Ruff (check)
         run: uv run ruff check
-      - name: Run Ty
+      - name: Ruff (format)
+        run: uv run ruff format --diff --check
+      - name: Ty
         run: uv run ty check
+      - name: Troml
+        run: uv run troml check
       - name: Run SonarQube
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ dev = [
 [tool.pytest.ini_options]
 addopts = "--cov=tpc_plugin_validator --cov-report term-missing --cov-report xml:coverage.xml"
 
-[tool.isort]
-py_version={ PYTHON VERSION NO DOT }
+[tool.ruff]
+line-length = 120

--- a/setup.sh
+++ b/setup.sh
@@ -71,8 +71,9 @@ function setup_issue_templates {
 
 function set_python_version {
     header 'Python Version'
-    read -rp 'What is the minimum targetted python version? ' python_min
+    read -rp 'What is the minimum targeted python version? ' python_min
     python_version_no_dot="${python_min//.}"
+    sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" '.github/workflows/publish.yml'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" '.github/workflows/uv.yml'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" '.python-version'
     sed -i '' -e "s/{ PYTHON VERSION }/$python_min/g" 'pyproject.toml'


### PR DESCRIPTION
Updated workflows to use native UV tools.

## Summary by Sourcery

Leverage native uv commands across CI workflows for testing, linting, formatting, typing, and TOML validation, add a new GitHub Actions workflow to build and publish the package to PyPI, consolidate linting configuration under ruff, and enhance the setup script for consistent Python version management.

Enhancements:
- Consolidate linting and formatting under a ruff configuration with a 120-character line length
- Extend setup.sh to update Python version placeholders across workflows and fix a prompt typo

CI:
- Migrate uv.yml CI steps to use uv commands for pytest, ruff check, ruff format, ty, and troml
- Add a new publish workflow to build via uv and publish distributions to PyPI on pushes to main